### PR TITLE
Fixing: Dart Unhandled Exception: type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0-nullsafety.4
+ - Fixed wrong null usage
+
 ## 3.0.0-nullsafety.3
  - Fixed unexpected null value
 

--- a/lib/src/ddp/collection.dart
+++ b/lib/src/ddp/collection.dart
@@ -17,10 +17,10 @@ Tuple2<String, Map<String, dynamic>> _parse(Map<String, dynamic> update) {
           return Tuple2(_id, _updates as Map<String, dynamic>);
         }
       }
-      return Tuple2(_id, null as Map<String, dynamic>);
+      return Tuple2(_id, {} as Map<String, dynamic>);
     }
   }
-  return Tuple2('', null as Map<String, dynamic>);
+  return Tuple2('', {} as Map<String, dynamic>);
 }
 
 abstract class Collection {


### PR DESCRIPTION
This error occurs every time I remove a document on the meteor server.

The stack trace showed me that this error came from these lines:
`return Tuple2(_id, null as Map<String, dynamic>);`
`return Tuple2('', null as Map<String, dynamic>);`

This is not null safe because null can't be something else now.

I now changed it into
`{} as Map<String, dynamic>`
But I'm not completely sure if I break something else with that.